### PR TITLE
chore: Changes name to httprequest-lego-k8s

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         with:
           name: tested-charm
-          path: .tox/**/httpreq-acme-operator_ubuntu-22.04-amd64.charm
+          path: .tox/**/httprequest-lego-k8s_ubuntu-22.04-amd64.charm
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
@@ -93,7 +93,7 @@ jobs:
         with:
           name: tested-charm
       - name: Move charm in current directory
-        run: find ./ -name httpreq-acme-operator_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
+        run: find ./ -name httprequest-lego-k8s_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.4.0
         id: channel

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# httpreq ACME Operator (K8s)
-[![CharmHub Badge](https://charmhub.io/httpreq-acme-operator/badge.svg)](https://charmhub.io/httpreq-acme-operator)
+# httpreq LEGO Operator (K8s)
+[![CharmHub Badge](https://charmhub.io/httprequest-lego-k8s/badge.svg)](https://charmhub.io/httprequest-lego-k8s)
 
-ACME operator implementing the provider side of the `tls-certificates`
+LEGO operator implementing the provider side of the `tls-certificates`
 interface to get signed certificates from the `Let's Encrypt` ACME server
 using the HTTP Request plugin for DNS-01 challenge.
 
@@ -20,21 +20,21 @@ provided to as a configuration to this operator.
 Create a YAML configuration file with the following fields:
 
 ```yaml
-httpreq-acme-operator:
+httprequest-lego-k8s:
   email: <Account email address>
   httpreq_endpoint: <HTTP/HTTPS URL>
 ```
 
-Deploy `httpreq-acme-operator`:
+Deploy `httprequest-lego-k8s`:
 
 ```bash
-juju deploy httpreq-acme-operator --config <yaml config file>
+juju deploy httprequest-lego-k8s --config <yaml config file>
 ```
 
 Relate it to a `tls-certificates-requirer` charm:
 
 ```bash
-juju relate httpreq-acme-operator:certificates <tls-certificates-requirer>
+juju relate httprequest-lego-k8s:certificates <tls-certificates-requirer>
 ````
 
 ## Config

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""# acme_client Library.
+"""# lego_client Library.
 
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.
@@ -9,7 +9,7 @@ This library contains all the logic necessary to get certificates from an ACME s
 ## Getting Started
 To get started using the library, you need to fetch the library using `charmcraft`.
 ```shell
-charmcraft fetch-lib charms.acme_client_operator.v0.acme_client
+charmcraft fetch-lib charms.lego_client_operator.v0.lego_client
 ```
 You will also need to add the following library to the charm's `requirements.txt` file:
 - jsonschema
@@ -17,7 +17,7 @@ You will also need to add the following library to the charm's `requirements.txt
 
 Then, to use the library in an example charm, you can do the following:
 ```python
-from charms.acme_client_operator.v0.acme_client import AcmeClient
+from charms.lego_client_operator.v0.lego_client import AcmeClient
 from ops.main import main
 class ExampleAcmeCharm(AcmeClient):
     def __init__(self, *args):
@@ -78,14 +78,15 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.pebble import ExecError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "b3c9913b68dc42b89dfd0e77ac57236d"
+LIBID = "d67f92a288e54ab68a6b6349e9b472c4"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
+
 
 logger = logging.getLogger(__name__)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,21 +1,21 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: httpreq-acme-operator
+name: httprequest-lego-k8s
 
-display-name: HTTP Request ACME Operator
+display-name: HTTP Request LEGO (K8s)
 
 description: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
   using the HTTP Request plugin for DNS-01 challenge.
 summary: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
   using the HTTP Request plugin for DNS-01 challenge.
-website: https://charmhub.io/httpreq-acme-operator
-source: https://github.com/canonical/httpreq-acme-operator
-issues: https://github.com/canonical/httpreq-acme-operator/issues
+website: https://charmhub.io/httprequest-lego-k8s
+source: https://github.com/canonical/httprequest-lego-k8s-operator
+issues: https://github.com/canonical/httprequest-lego-k8s-operator/issues
 docs: https://discourse.charmhub.io/t/http-request-acme-operator-docs-index/12513
 
 provides:

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,18 +8,18 @@ import logging
 from typing import Dict
 from urllib.parse import urlparse
 
-from charms.acme_client_operator.v0.acme_client import AcmeClient  # type: ignore[import]
+from charms.lego_base_k8s.v0.lego_client import AcmeClient  # type: ignore[import]
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
 logger = logging.getLogger(__name__)
 
 
-class HTTPReqAcmeOperatorCharm(AcmeClient):
+class HTTPRequestLegoK8s(AcmeClient):
     """Main class that is instantiated every time an event occurs."""
 
     def __init__(self, *args):
-        """Uses the acme_client library to manage events."""
+        """Uses the lego_client library to manage events."""
         super().__init__(*args, plugin="httpreq")
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
@@ -109,4 +109,4 @@ class HTTPReqAcmeOperatorCharm(AcmeClient):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(HTTPReqAcmeOperatorCharm)
+    main(HTTPRequestLegoK8s)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,12 +9,12 @@ from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from parameterized import parameterized  # type: ignore[import]
 
-from charm import HTTPReqAcmeOperatorCharm
+from charm import HTTPRequestLegoK8s
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(HTTPReqAcmeOperatorCharm)
+        self.harness = Harness(HTTPRequestLegoK8s)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 


### PR DESCRIPTION
# Description

This PR changes the charm name from `httpreq-acme-operator` to `httprequest-lego-k8s` in order to follow the charm naming convention.

## Reference
- https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit
- https://juju.is/docs/sdk/naming

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
