### PR TITLE
fix: Specifies dependency version in tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,6 +52,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
+          juju-channel: 3.3/stable
       - name: Run integration tests
         run: tox -e integration
       - name: Archive Tested Charm

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,21 @@
+black
+codespell
+coverage[toml]
+cryptography
+flake8 == 4.0.1
+flake8-copyright
+flake8-builtins
+flake8-docstrings
+isort
+jsonschema
+juju
+mypy
+ops
+parameterized
+pep8-naming
+pyproject-flake8
+pytest
+pytest-operator
+types-PyYAML
+types-setuptools
+types-toml

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 passenv =
   PYTHONPATH
   CHARM_BUILD_DIR
@@ -24,25 +27,12 @@ passenv =
 
 [testenv:fmt]
 description = Apply coding style standards to code
-deps =
-    black
-    isort
 commands =
     isort {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
-deps =
-    black
-    flake8 == 4.0.1
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-    codespell
 commands =
     codespell {[vars]all_path}
     pflake8 {[vars]all_path}
@@ -51,15 +41,6 @@ commands =
 
 [testenv:static]
 description = Run static analysis checks
-deps =
-    -r{toxinidir}/requirements.txt
-    mypy
-    types-PyYAML
-    pytest
-    pytest-operator
-    juju
-    types-setuptools
-    types-toml
 setenv =
     PYTHONPATH = ""
 commands =
@@ -67,20 +48,11 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
-deps =
-    pytest
-    coverage[toml]
-    -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
 
 [testenv:integration]
 description = Run integration tests
-deps =
-    pytest
-    juju<3.1
-    pytest-operator
-    -r{toxinidir}/requirements.txt
 commands =
     pytest --asyncio-mode=auto -v --tb native {[vars]integration_test_path} --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
# Description

There were a couple issues that caused CI failures. This PR addresses all of them:

- Uses strictly confined microk8s in integration tests CI workflow.
- Specifies Juju version in integration tests CI workflow
- Moves all test dependencies from tox.ini to test-requirements.txt

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
