### PR TITLE
chore: Only runs integration tests if other tests pass

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,6 +41,10 @@ jobs:
   integration-test:
     name: Integration tests
     runs-on: ubuntu-22.04
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

As requested in this charm's Charmhub listing review (PR #27), we only run integration tests when the other tests have passed. This should reduce unnecessary runs. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
