### PR TITLE
fix: Asserts charm is active after related to the cert requirer

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -55,6 +55,10 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
     )
 
 
+@pytest.mark.xfail(
+    reason="The charm will fail requesting a certificate from the ACME server, \
+        because http_req is invalid and will be blocked."
+)
 async def test_given_tls_requirer_is_deployed_and_related_then_status_is_active(
     ops_test: OpsTest,
     build_and_deploy,
@@ -64,7 +68,7 @@ async def test_given_tls_requirer_is_deployed_and_related_then_status_is_active(
         relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
     )
     await ops_test.model.wait_for_idle(
-        apps=[TLS_REQUIRER_CHARM_NAME],
+        apps=[APP_NAME],
         status="active",
         timeout=1000,
     )


### PR DESCRIPTION
# Description

- Asserts charm is active after related to the cert requirer instead of checking the requirer
- The test is expected to fail now due to using an invalid httpreq_endpoint, xfail is used

Fixes #45 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ x Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
