### PR TITLE
chore: Removes documentation from README and link to docs on Charmhub instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,60 +3,9 @@
 
 LEGO operator implementing the provider side of the `tls-certificates`
 interface to get signed certificates from the `Let's Encrypt` ACME server
-using the HTTP Request plugin for DNS-01 challenge.
+using the HTTP Request plugin of the LEGO client and the DNS-01 challenge.
 
-# Pre-requisites
-
-This charm is a provider of the [`tls-certificates-interface`](https://github.com/canonical/tls-certificates-interface),
-charms that require Let's Encrypt certificates need to implement the requirer side.
-
-This operator targets a custom implementation of an API defined in
-[`go-acme lego documentation`](https://go-acme.github.io/lego/dns/httpreq/).
-This custom API needs be implemented for you particular use case and its URL
-provided to as a configuration to this operator.
-
-## Usage
-
-Create a YAML configuration file with the following fields:
-
-```yaml
-httprequest-lego-k8s:
-  email: <Account email address>
-  httpreq_endpoint: <HTTP/HTTPS URL>
-```
-
-Deploy `httprequest-lego-k8s`:
-
-```bash
-juju deploy httprequest-lego-k8s --config <yaml config file>
-```
-
-Relate it to a `tls-certificates-requirer` charm:
-
-```bash
-juju relate httprequest-lego-k8s:certificates <tls-certificates-requirer>
-````
-
-## Config
-
-### Required configuration properties
-
-- email: Let's Encrypt email address
-- httpreq_endpoint: HTTP/HTTPS URL to the service implementing the HTTPREQ API
-
-### Optional configuration properties
-
-- server: Let's Encrypt server to use (default: `https://acme-v02.api.letsencrypt.org/directory`)
-- httpreq_http_timeout: API request timeout
-- httpreq_mode: "'RAW' or None"
-- httpreq_password: Basic authentication password
-- httpreq_polling_interval: Time between DNS propagation checks
-- httpreq_propagation_timeout: Maximum waiting time for DNS propagation
-- httpreq_username: Basic authentication username
-
-## Relations
-
-- `certificates`: `tls-certificates-interface` provider
+For more information including guides, integrations, configuration options, see [HTTP Request LEGO's Charmhub page](https://charmhub.io/httprequest-lego-k8s).
 
 ## OCI Images
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,14 +1,14 @@
 options:
   email:
     type: string
-    description: Account email address
+    description: Account email address, this email will receive notifications from Let's Encrypt.
   server:
     type: string
     description: Certificate authority server
     default: "https://acme-v02.api.letsencrypt.org/directory"
   httpreq_endpoint:
     type: string
-    description: URL of the HTTP endpoint to use
+    description: URL of the custom API that can be used to fulfill the DNS-01 challenge
   httpreq_http_timeout:
     type: int
     description: API request timeout

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,11 +8,11 @@ display-name: HTTP Request LEGO (K8s)
 description: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using the HTTP Request plugin for DNS-01 challenge.
+  using the HTTP Request plugin of the LEGO client and the DNS-01 challenge.
 summary: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using the HTTP Request plugin for DNS-01 challenge.
+  using the HTTP Request plugin of the LEGO client and the DNS-01 challenge.
 website: https://charmhub.io/httprequest-lego-k8s
 source: https://github.com/canonical/httprequest-lego-k8s-operator
 issues: https://github.com/canonical/httprequest-lego-k8s-operator/issues


### PR DESCRIPTION
# Description

- Improves the README file and the metadata.yaml file
- Improves the explanation of the config options in the config file

**Note for reviewers:**
**Please take a look at the enhanced docs in Charmhub:**
- https://discourse.charmhub.io/t/http-request-lego-operator-k8s-docs-index/12513
- https://discourse.charmhub.io/t/http-request-lego-reference/13248

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
