### PR TITLE
fix: Uses type conversion for int config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,9 +10,9 @@ options:
     type: string
     description: URL of the custom API that can be used to fulfill the DNS-01 challenge
   httpreq_http_timeout:
-    type: string
+    type: int
     description: API request timeout (seconds)
-    default: "30"
+    default: 30
   httpreq_mode:
     type: string
     description: "'RAW' or None"
@@ -20,13 +20,13 @@ options:
     type: string
     description: Basic authentication password
   httpreq_polling_interval:
-    type: string
+    type: int
     description: Time between DNS propagation check (seconds)
-    default: "2"
+    default: 2
   httpreq_propagation_timeout:
-    type: string
+    type: int
     description: Maximum waiting time for DNS propagation (seconds)
-    default: "60"
+    default: 60
   httpreq_username:
     type: string
     description: Basic authentication username

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ class HTTPRequestLegoK8s(AcmeClient):
     @property
     def _httpreq_http_timeout(self) -> str:
         """Returns HTTP Request http timeout from config."""
-        return self.model.config.get("httpreq_http_timeout")
+        return str(self.model.config.get("httpreq_http_timeout"))
 
     @property
     def _httpreq_password(self) -> str:
@@ -46,12 +46,12 @@ class HTTPRequestLegoK8s(AcmeClient):
     @property
     def _httpreq_polling_interval(self) -> str:
         """Returns HTTP Request polling interval from config."""
-        return self.model.config.get("httpreq_polling_interval")
+        return str(self.model.config.get("httpreq_polling_interval"))
 
     @property
     def _httpreq_propagation_timeout(self) -> str:
         """Returns HTTP Request propagation timeout from config."""
-        return self.model.config.get("httpreq_propagation_timeout")
+        return str(self.model.config.get("httpreq_propagation_timeout"))
 
     @property
     def _httpreq_username(self) -> str:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -73,11 +73,11 @@ class TestCharm(unittest.TestCase):
             {
                 "email": "example@email.com",
                 "httpreq_endpoint": "http://dummy.url.com",
-                "httpreq_http_timeout": "5",
+                "httpreq_http_timeout": 5,
                 "httpreq_mode": "RAW",
                 "httpreq_password": "qwerty123",
-                "httpreq_polling_interval": "30",
-                "httpreq_propagation_timeout": "10",
+                "httpreq_polling_interval": 30,
+                "httpreq_propagation_timeout": 10,
                 "httpreq_username": "bob",
             }
         )
@@ -88,11 +88,11 @@ class TestCharm(unittest.TestCase):
             {
                 "email": "example@email.com",
                 "httpreq_endpoint": "http://dummy.url.com",
-                "httpreq_http_timeout": "5",
+                "httpreq_http_timeout": 5,
                 "httpreq_mode": "RAW",
                 "httpreq_password": "qwerty123",
-                "httpreq_polling_interval": "30",
-                "httpreq_propagation_timeout": "10",
+                "httpreq_polling_interval": 30,
+                "httpreq_propagation_timeout": 10,
                 "httpreq_username": "bob",
             }
         )


### PR DESCRIPTION
# Description

Uses type conversion for config options that are int instead of allowing the user to provide strings.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
