### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,7 @@
 """Retrieves certificates from an ACME server using the HTTP Request dns provider."""
 
 import logging
-from typing import Dict
+from typing import Dict, cast
 from urllib.parse import urlparse
 
 from charms.lego_base_k8s.v0.lego_client import AcmeClient
@@ -24,12 +24,12 @@ class HTTPRequestLegoK8s(AcmeClient):
     @property
     def _httpreq_endpoint(self) -> str:
         """Return HTTP Request endpoint from config."""
-        return self.model.config.get("httpreq_endpoint", "")
+        return cast(str, self.model.config.get("httpreq_endpoint", ""))
 
     @property
     def _httpreq_mode(self) -> str:
         """Return HTTP Request mode from config."""
-        return self.model.config.get("httpreq_mode", "")
+        return cast(str, self.model.config.get("httpreq_mode", ""))
 
     @property
     def _httpreq_http_timeout(self) -> str:
@@ -39,7 +39,7 @@ class HTTPRequestLegoK8s(AcmeClient):
     @property
     def _httpreq_password(self) -> str:
         """Return HTTP Request password from config."""
-        return self.model.config.get("httpreq_password", "")
+        return cast(str, self.model.config.get("httpreq_password", ""))
 
     @property
     def _httpreq_polling_interval(self) -> str:
@@ -54,7 +54,7 @@ class HTTPRequestLegoK8s(AcmeClient):
     @property
     def _httpreq_username(self) -> str:
         """Return HTTP Request username from config."""
-        return self.model.config.get("httpreq_username", "")
+        return cast(str, self.model.config.get("httpreq_username", ""))
 
     @property
     def _plugin_config(self) -> Dict[str, str]:


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A
