### PR TITLE
fix: freeze lxd to 5.20/stable

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,14 +52,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup LXD
-        uses: canonical/setup-lxd@main
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
           channel: 1.29-strict/stable
           juju-channel: 3.4/stable
+          lxd-channel: 5.20/stable
       - name: Run integration tests
         run: tox -e integration
       - name: Archive Tested Charm


### PR DESCRIPTION
# Description

Charmcraft currently does not work with the latest lxd version (5.21/stable). This prevents other PR's being merged because of CI failures. This change freezes lxd to 5.20/stable. 

## Reference
- https://github.com/canonical/charmcraft/issues/1640

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
