### PR TITLE
chore: increase default timeout for http requests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ options:
   httpreq_http_timeout:
     type: int
     description: API request timeout (seconds)
-    default: 30
+    default: 180
   httpreq_mode:
     type: string
     description: "'RAW' or None"


### PR DESCRIPTION
# Description

If a provider has some involved operations to do as part of fulfilling a `/present` or `/cleanup` request (such as downloading a git repo, committing a change and pushing it) this can sometimes take more than 30 seconds. Updating the default timeout means clients connecting to such providers wouldn't need to increase the timeout.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [N/A] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [N/A] I have bumped the version of the library
