### PR TITLE
fix: Uses release-charm@2.5.0-rc

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -33,7 +33,7 @@ jobs:
             echo "promote-to=stable" >> ${GITHUB_ENV}
           fi
       - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.4.0
+        uses: canonical/charming-actions/release-charm@2.5.0-rc
         with:
           base-channel: 22.04
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}


### PR DESCRIPTION
# Description

The promote action seems to break because of the recent move from using metadata.yaml to centrealizing everything in charmcraft.yaml. `2.5.0-rc` should include a fix to this.
Error message:
```
Run canonical/charming-actions/release-charm@2.4.0
/usr/bin/sudo snap install charmcraft --classic --channel latest/stable
charmcraft 2.6.0 from Canonical** installed
Error: ENOENT: no such file or directory, open 'metadata.yaml'
Error: Error: ENOENT: no such file or directory, open 'metadata.yaml'
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
