### PR TITLE
chore: reduce summary to < 200 chars

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,9 +8,7 @@ description: |
   interface to get signed certificates from the `Let's Encrypt` ACME server
   using the HTTP Request plugin of the LEGO client and the DNS-01 challenge.
 summary: |
-  LEGO operator implementing the provider side of the `tls-certificates`
-  interface to get signed certificates from the `Let's Encrypt` ACME server
-  using the HTTP Request plugin of the LEGO client and the DNS-01 challenge.
+  Get signed certificates from `Let's Encrypt`using the HTTP Request LEGO plugin.
 links:
   website:
     - https://charmhub.io/httprequest-lego-k8s


### PR DESCRIPTION
# Description

The summary size was preventing the charm to be built. This seems to be new with charmcraft 3.1.1.

Reference:
- https://github.com/canonical/httprequest-lego-k8s-operator/pull/196

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
