### PR TITLE
chore: bump juju, lxd, and microk8s versions in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.20/stable
+            channel: 5.21/stable
     
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,9 +24,9 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.29-strict/stable
-          juju-channel: 3.4/stable
-          lxd-channel: 5.20/stable
+          channel: 1.31-strict/stable
+          juju-channel: 3.6/stable
+          lxd-channel: 5.21/stable
   
       - name: Run integration tests
         run: |


### PR DESCRIPTION
# Description

- Bump Juju to `3.6/stable`
- Bump lxd to `5.21/stable`
- Bump MicroK8s to `1.31-strict/stable`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
