### PR TITLE
chore: Adds a deprecation notice in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+## Deprecation Notice
+
+**This charm is no longer supported, please consider using [lego-operator](https://github.com/canonical/lego-operator) or [notary-k8s-operator](https://github.com/canonical/notary-k8s-operator) instead.**
+
 # httpreq LEGO Operator (K8s)
+
 [![CharmHub Badge](https://charmhub.io/httprequest-lego-k8s/badge.svg)](https://charmhub.io/httprequest-lego-k8s)
 
 LEGO operator implementing the provider side of the `tls-certificates`
@@ -9,4 +14,4 @@ For more information including guides, integrations, configuration options, see 
 
 ## OCI Images
 
--  [Lego Rock Image](https://github.com/canonical/lego-rock)
+- [Lego Rock Image](https://github.com/canonical/lego-rock)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Deprecation Notice
 
-**This charm is no longer supported, please consider using [lego-operator](https://github.com/canonical/lego-operator) or [notary-k8s-operator](https://github.com/canonical/notary-k8s-operator) instead.**
+**This charm is no longer supported, please use [lego-operator](https://github.com/canonical/lego-operator) instead.**
 
 # httpreq LEGO Operator (K8s)
 

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -3,6 +3,8 @@
 
 """# lego_client Library.
 
+Deprecation Notice: This library is deprecated. Please use the lego charm instead: https://charmhub.io/lego.
+
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.
 
@@ -77,7 +79,7 @@ import logging
 import os
 import re
 from abc import abstractmethod
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlparse
 
 from charms.certificate_transfer_interface.v1.certificate_transfer import (
@@ -103,7 +105,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 
 logger = logging.getLogger(__name__)
@@ -120,8 +122,9 @@ class AcmeClient(CharmBase):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, *args, plugin: str):
+    def __init__(self, *args: Any, plugin: str):
         super().__init__(*args)
+        logger.warning("This library is deprecated. Please use the lego charm instead.")
         self._csr_path = "/tmp/csr.pem"
         self._certs_path = "/tmp/.lego/certificates/"
         self._container_name = list(self.meta.containers.values())[0].name
@@ -225,7 +228,7 @@ class AcmeClient(CharmBase):
         )
         try:
             stdout, error = process.wait_output()
-            logger.info(f"Return message: {stdout}, {error}")
+            logger.info("Return message: %s, %s", stdout, error)
         except ExecError as e:
             logger.error("Exited with code %d. Stderr:", e.exit_code)
             for line in e.stderr.splitlines():  # type: ignore


### PR DESCRIPTION
# Description

This PR adds a deprecation notice in the README. Once the PR is approved the following will happen:

- Update the description of the repo with the same notice.
- Un-list the charm from Charmhub

This PR bumps the lib to the latest version that includes a deprecation notice too.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
